### PR TITLE
Fix never resolving Promise

### DIFF
--- a/javascript/JZZ.js
+++ b/javascript/JZZ.js
@@ -2545,6 +2545,12 @@
           JZZ().or(ready).and(function() {
             var info = this.info();
             counter = info.inputs.length + info.outputs.length;
+            // Promise never resolves or rejects if no inputs and outputs are available; this happens
+            // for instance when no Jazz plugin or extension is installed.
+            if(counter === 0) {
+              resolve(wma);
+              return;
+            }
             var i, p;
             for (i = 0; i < info.outputs.length; i++) {
               p = new MIDIOutput(info.outputs[i]);


### PR DESCRIPTION
navigator.requestMIDIAccess never resolves or rejects when:
- no Jazz plugin or extension has been installed
- the system doesn't have any available MIDI in- and outputs